### PR TITLE
Add list.clear() in the C++ API.

### DIFF
--- a/include/pybind11/pytypes.h
+++ b/include/pybind11/pytypes.h
@@ -2195,6 +2195,7 @@ public:
             throw error_already_set();
         }
     }
+    void clear() { PyList_SetSlice(m_ptr, 0, PyList_Size(m_ptr), nullptr); }
 };
 
 class args : public tuple {

--- a/tests/test_pytypes.cpp
+++ b/tests/test_pytypes.cpp
@@ -135,6 +135,7 @@ TEST_SUBMODULE(pytypes, m) {
     m.def("list_size_t", []() { return py::list{(py::size_t) 0}; });
     m.def("list_insert_ssize_t", [](py::list *l) { return l->insert((py::ssize_t) 1, 83); });
     m.def("list_insert_size_t", [](py::list *l) { return l->insert((py::size_t) 3, 57); });
+    m.def("list_clear", [](py::list *l) { l->clear(); });
     m.def("get_list", []() {
         py::list list;
         list.append("value");

--- a/tests/test_pytypes.py
+++ b/tests/test_pytypes.py
@@ -65,6 +65,8 @@ def test_list(capture, doc):
     assert lins == [1, 83, 2]
     m.list_insert_size_t(lins)
     assert lins == [1, 83, 2, 57]
+    m.list_clear(lins)
+    assert lins == []
 
     with capture:
         lst = m.get_list()


### PR DESCRIPTION
## Description

Add list.clear() in the C++ API, this allows resetting a list (e.g. for doing function argument modification and such).
Append() is already present but there is currently no way to alter or remove items from a list.

## Suggested changelog entry:

Add pybind11::list::clear() in C++.
