### PR TITLE
Cleanup: Systematically change pywrapcc to pybind11k

### DIFF
--- a/docs/classes.rst
+++ b/docs/classes.rst
@@ -557,4 +557,4 @@ The ``name`` property returns the name of the enum value as a unicode string.
 .. note::
 
     ``py::native_enum`` was added as an alternative to ``py::enum_``
-    with http://github.com/google/pywrapcc/pull/30005
+    with http://github.com/google/pybind11k/pull/30005

--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -198,7 +198,7 @@ inline bool ensure_base_init_functions_were_called(PyObject *self) {
     return true;
 }
 
-// See google/pywrapcc#30095 for background.
+// See google/pybind11k#30095 for background.
 #if !defined(PYBIND11_INIT_SAFETY_CHECKS_VIA_INTERCEPTING_TP_INIT)                                \
     && !defined(PYBIND11_INIT_SAFETY_CHECKS_VIA_DEFAULT_PYBIND11_METACLASS)
 #    if !defined(PYPY_VERSION)

--- a/include/pybind11/detail/function_record_pyobject.h
+++ b/include/pybind11/detail/function_record_pyobject.h
@@ -2,7 +2,7 @@
 // All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// For background see the description of PR google/pywrapcc#30099.
+// For background see the description of PR google/pybind11k#30099.
 
 #pragma once
 

--- a/include/pybind11/detail/internals.h
+++ b/include/pybind11/detail/internals.h
@@ -148,7 +148,7 @@ struct internals {
 #    if PYBIND11_INTERNALS_VERSION > 4
     // Note that we have to use a std::string to allocate memory to ensure a unique address
     // We want unique addresses since we use pointer equality to compare function records
-    // OBSOLETE: google/pywrapcc#30099
+    // OBSOLETE: google/pybind11k#30099
     std::string function_record_capsule_name = internals_function_record_capsule_name;
 #    endif
 

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -413,7 +413,7 @@ protected:
         if (rec->name == nullptr) {
             rec->name = guarded_strdup("");
         } else if (std::strcmp(rec->name, "__setstate__[non-constructor]") == 0) {
-            // See google/pywrapcc#30094 for background.
+            // See google/pybind11k#30094 for background.
             rec->name = guarded_strdup("__setstate__");
         } else {
             rec->name = guarded_strdup(rec->name);

--- a/include/pybind11/stl.h
+++ b/include/pybind11/stl.h
@@ -377,7 +377,7 @@ private:
     bool convert_elements(handle seq, bool convert) {
         auto l = reinterpret_borrow<sequence>(seq);
         value.reset(new ArrayType{});
-        // Using `resize` to preserve the behavior exactly as it was before google/pywrapcc#30034
+        // Using `resize` to preserve the behavior exactly as it was before google/pybind11k#30034
         // For the `resize` to work, `Value` must be default constructible.
         // For `std::valarray`, this is a requirement:
         // https://en.cppreference.com/w/cpp/named_req/NumericType
@@ -453,7 +453,7 @@ public:
     }
 
     // Code copied from PYBIND11_TYPE_CASTER macro.
-    // Intentionally preserving the behavior exactly as it was before google/pywrapcc#30034
+    // Intentionally preserving the behavior exactly as it was before google/pybind11k#30034
     template <typename T_, enable_if_t<std::is_same<ArrayType, remove_cv_t<T_>>::value, int> = 0>
     static handle cast(T_ *src, const return_value_policy_pack &policy, handle parent) {
         if (!src) {

--- a/tests/test_pickling.cpp
+++ b/tests/test_pickling.cpp
@@ -65,7 +65,7 @@ void wrap(py::module m) {
 
 namespace exercise_getinitargs_getstate_setstate {
 
-// Exercise `__setstate__[non-constructor]` (see google/pywrapcc#30094), which
+// Exercise `__setstate__[non-constructor]` (see google/pybind11k#30094), which
 // was added to support a pickle protocol as established with Boost.Python
 // (in 2002):
 //   https://www.boost.org/doc/libs/1_31_0/libs/python/doc/v2/pickle.html
@@ -103,7 +103,7 @@ void wrap(py::module m) {
             },
             py::arg("protocol") = -1)
         .def(
-            "__setstate__[non-constructor]", // See google/pywrapcc#30094 for background.
+            "__setstate__[non-constructor]", // See google/pybind11k#30094 for background.
             [](StoreTwoWithState *self, const std::string &state) { self->SetState(state); },
             py::arg("state"));
 }


### PR DESCRIPTION
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description
Belated minor follow-on to google/pybind11k#30108.

This is to avoid confusing people with an obsolete name.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
